### PR TITLE
(+) Update Ed25519 usage for iroha v1.

### DIFF
--- a/protos/block.proto
+++ b/protos/block.proto
@@ -10,7 +10,7 @@ message Header {
 
  message Transaction {
   message Payload {
-     repeated Command commands = 1;
+    repeated Command commands = 1;
     string creator_account_id = 2;
     uint64 tx_counter  = 3;
     uint64 created_time = 4;
@@ -23,10 +23,9 @@ message Header {
  message Block {
   // everything that should be signed:
   message Payload {
-     repeated Transaction transactions = 1;
+    repeated Transaction transactions = 1;
     uint32 tx_number = 2; // the number of transactions inside. Maximum 16384 or 2^14
     uint64 height = 3; // the current block number in a ledger
-    bytes merkle_root = 4; // global merkle root
     bytes prev_block_hash = 5; // Previous block hash
     uint64 created_time = 6;
    }

--- a/protos/commands.proto
+++ b/protos/commands.proto
@@ -64,6 +64,11 @@ message AppendRole {
     string role_name = 2;
 }
 
+message DetachRole {
+    string account_id = 1;
+    string role_name = 2;
+}
+
 message CreateRole {
     string role_name = 1;
     repeated RolePermission permissions = 2;
@@ -79,21 +84,29 @@ message RevokePermission {
     GrantablePermission permission = 2;
 }
 
+message SubtractAssetQuantity {
+    string account_id = 1;
+    string asset_id = 2;
+    Amount amount = 3;
+}
+
 message Command {
     oneof command {
         AddAssetQuantity add_asset_quantity = 1;
         AddPeer add_peer = 2;
         AddSignatory add_signatory = 3;
-        CreateAsset create_asset = 4;
+        AppendRole append_role = 4;
         CreateAccount create_account = 5;
-        CreateDomain create_domain = 6;
-        RemoveSignatory remove_sign = 7;
-        SetAccountQuorum set_quorum = 9;
-        TransferAsset transfer_asset = 10;
-        AppendRole append_role = 11;
-        CreateRole create_role = 12;
-        GrantPermission grant_permission = 13;
-        RevokePermission revoke_permission = 14;
-        SetAccountDetail set_account_detail = 15;
+        CreateAsset create_asset = 6;
+        CreateDomain create_domain = 7;
+        CreateRole create_role = 8;
+        DetachRole detach_role = 9;
+        GrantPermission grant_permission = 10;
+        RemoveSignatory remove_sign = 11;
+        RevokePermission revoke_permission = 12;
+        SetAccountDetail set_account_detail = 13;
+        SetAccountQuorum set_quorum = 14;
+        SubtractAssetQuantity subtract_asset_quantity = 15;
+        TransferAsset transfer_asset = 16;
     }
 }

--- a/protos/endpoint.proto
+++ b/protos/endpoint.proto
@@ -14,12 +14,13 @@ enum TxStatus {
   STATEFUL_VALIDATION_FAILED = 2;
   STATEFUL_VALIDATION_SUCCESS = 3;
   COMMITTED = 4;
-  ON_PROCESS = 5;
+  IN_PROGRESS = 5;
   NOT_RECEIVED = 6;
 }
 
 message ToriiResponse {
   TxStatus tx_status = 1;
+  bytes tx_hash = 2;
 }
 
 message TxStatusRequest{

--- a/protos/primitive.proto
+++ b/protos/primitive.proto
@@ -4,6 +4,7 @@ package iroha.protocol;
 enum RolePermission {
    // Command Permissions
     can_append_role = 0;
+    can_detach_role = 31;
     can_create_role = 1;
     can_add_asset_qty = 2;
     can_add_peer = 3;
@@ -15,30 +16,36 @@ enum RolePermission {
     can_set_quorum = 9;
     can_transfer = 10;
     can_receive = 11;
+    can_subtract_asset_qty = 12;
    // Query permissions
-    can_read_assets = 12;
-    can_get_roles = 13;
-    can_get_my_account = 14;
-    can_get_all_accounts = 15;
-    can_get_my_signatories = 16;
-    can_get_all_signatories = 17;
-    can_get_my_acc_ast = 18;
-    can_get_all_acc_ast = 19;
-    can_get_my_acc_txs = 20;
-    can_get_all_acc_txs = 21;
-    can_get_my_acc_ast_txs = 22;
-    can_get_all_acc_ast_txs = 23;
+    can_read_assets = 13;
+    can_get_roles = 14;
+    can_get_my_account = 15;
+    can_get_all_accounts = 16;
+    can_get_my_signatories = 17;
+    can_get_all_signatories = 18;
+    can_get_my_acc_ast = 19;
+    can_get_my_acc_detail = 20;
+    can_get_all_acc_ast = 21;
+    can_get_my_acc_txs = 22;
+    can_get_all_acc_txs = 23;
+    can_get_my_acc_ast_txs = 24;
+    can_get_all_acc_ast_txs = 25;
+    can_get_my_txs = 32;
+    can_get_all_txs = 33;
    // Grant permissions
-    can_grant_add_signatory = 24;
-    can_grant_remove_signatory = 25;
-    can_grant_set_quorum = 26;
-    can_grant_can_transfer = 27;
+    can_grant_add_signatory = 26;
+    can_grant_remove_signatory = 27;
+    can_grant_set_quorum = 28;
+    can_grant_can_transfer = 29;
+    can_grant_can_set_detail = 30;
 }
 
 enum GrantablePermission {
     can_add_my_signatory = 0;
     can_remove_my_signatory = 1;
     can_set_my_quorum = 2;
+    can_set_my_account_detail = 3;
 }
 
 

--- a/protos/queries.proto
+++ b/protos/queries.proto
@@ -20,9 +20,18 @@ message GetAccountAssetTransactions {
   string asset_id = 2;
 }
 
+message GetTransactions {
+  repeated bytes tx_hashes = 1;
+}
+
 message GetAccountAssets {
   string account_id = 1;
   string asset_id = 2;
+}
+
+message GetAccountDetail {
+  string account_id = 1;
+  string detail = 2;
 }
 
 message GetAssetInfo {
@@ -47,13 +56,15 @@ message Query {
        GetSignatories get_account_signatories = 4;
        GetAccountTransactions get_account_transactions = 5;
        GetAccountAssetTransactions get_account_asset_transactions = 6;
-       GetAccountAssets get_account_assets = 7;
-       GetRoles get_roles = 8;
-       GetAssetInfo get_asset_info = 9;
-       GetRolePermissions get_role_permissions = 10;
+       GetTransactions get_transactions = 7;
+       GetAccountAssets get_account_assets = 8;
+       GetAccountDetail get_account_detail = 9;
+       GetRoles get_roles = 10;
+       GetRolePermissions get_role_permissions = 11;
+       GetAssetInfo get_asset_info = 12;
      }
      // used to prevent replay attacks.
-     uint64 query_counter = 11;
+     uint64 query_counter = 13;
   }
 
   Payload payload = 1;

--- a/protos/responses.proto
+++ b/protos/responses.proto
@@ -14,6 +14,7 @@ message Account {
     string account_id = 1;
     string domain_id = 2;
     uint32 quorum = 3;
+    string json_data = 4;
 }
 
 message AccountAsset {
@@ -25,6 +26,10 @@ message AccountAsset {
 // *** Responses *** //
 message AccountAssetResponse {
     AccountAsset account_asset = 1;
+}
+
+message AccountDetailResponse {
+    string detail = 1;
 }
 
 message AccountResponse {
@@ -50,9 +55,9 @@ message ErrorResponse {
         STATEFUL_INVALID = 1;
         NO_ACCOUNT = 2; // when requested account does not exist
         NO_ACCOUNT_ASSETS = 3; // when requested account asset does not exist
-        NO_SIGNATORIES = 4; // when requested signatories does not exist
-        NOT_SUPPORTED = 5; // when unidentified request was received
-        WRONG_FORMAT = 6; // when json format wrong
+        NO_ACCOUNT_DETAIL = 4; // when requested account detail does not exist
+        NO_SIGNATORIES = 5; // when requested signatories does not exist
+        NOT_SUPPORTED = 6; // when unidentified request was received
         NO_ASSET = 7; // when requested asset does not exist
         NO_ROLES = 8; // when there are no roles defined in the system
     }
@@ -72,12 +77,14 @@ message TransactionsResponse {
 message QueryResponse {
     oneof response {
         AccountAssetResponse account_assets_response = 1;
-        AccountResponse account_response = 2;
-        ErrorResponse error_response = 3;
-        SignatoriesResponse signatories_response = 4;
-        TransactionsResponse transactions_response = 5;
-        AssetResponse asset_response = 6;
-        RolesResponse roles_response = 7;
-        RolePermissionsResponse role_permissions_response = 8;
+        AccountDetailResponse account_detail_response = 2;
+        AccountResponse account_response = 3;
+        ErrorResponse error_response = 4;
+        SignatoriesResponse signatories_response = 5;
+        TransactionsResponse transactions_response = 6;
+        AssetResponse asset_response = 7;
+        RolesResponse roles_response = 8;
+        RolePermissionsResponse role_permissions_response = 9;
     }
+    bytes query_hash = 10;
 }

--- a/src/main/scala/net/cimadai/crypto/SHA3EdDSAPrivateKeySpec.scala
+++ b/src/main/scala/net/cimadai/crypto/SHA3EdDSAPrivateKeySpec.scala
@@ -1,0 +1,91 @@
+package net.cimadai.crypto
+
+import java.security.{MessageDigest, NoSuchAlgorithmException}
+import java.util
+
+import net.i2p.crypto.eddsa.math.{Curve, GroupElement, ScalarOps}
+import net.i2p.crypto.eddsa.spec.{EdDSANamedCurveTable, EdDSAParameterSpec, EdDSAPrivateKeySpec}
+
+class SHA3EdDSAPrivateKeySpec(seed: Array[Byte], h: Array[Byte], a: Array[Byte], A: GroupElement, spec: EdDSAParameterSpec) extends
+  EdDSAPrivateKeySpec(seed, h, a, A, spec) {
+}
+
+object SHA3EdDSAPrivateKeySpec {
+  val b = 256
+
+  /**
+    * @param seed the private key
+    * @param spec the parameter specification for this key
+    * @throws IllegalArgumentException if seed length is wrong or hash algorithm is unsupported
+    */
+  def apply(seed: Array[Byte], spec: EdDSAParameterSpec): SHA3EdDSAPrivateKeySpec = {
+    if (seed.length != b/8) {
+      throw new IllegalArgumentException("seed length is wrong")
+    }
+
+    try {
+      val hash = MessageDigest.getInstance("SHA-512")
+
+      // H(k)
+      val h = hash.digest(seed)
+      //edDsaPrivateKeySha3_256Spec.h = hash.digest(seed)
+
+      /*a = BigInteger.valueOf(2).pow(b-2);
+      for (int i=3;i<(b-2);i++) {
+          a = a.add(BigInteger.valueOf(2).pow(i).multiply(BigInteger.valueOf(Utils.bit(h,i))));
+      }*/
+      // Saves ~0.4ms per key when running signing tests.
+      // TODO: are these bitflips the same for any hash function?
+      h(0) = (h(0) & 248.toByte).toByte
+      h((b/8)-1) = (h((b/8)-1) & 63.toByte).toByte
+      h((b/8)-1) = (h((b/8)-1) | 64.toByte).toByte
+      val a = util.Arrays.copyOfRange(h, 0, b/8)
+      val A = spec.getB.scalarMultiply(a)
+
+      new SHA3EdDSAPrivateKeySpec(seed, h, a, A, spec)
+    } catch {
+      case e: NoSuchAlgorithmException =>
+        throw new IllegalArgumentException("Unsupported hash algorithm")
+    }
+  }
+
+  /**
+    * Initialize directly from the hash.
+    * getSeed() will return null if this constructor is used.
+    *
+    * @param spec the parameter specification for this key
+    * @param h    the private key
+    * @throws IllegalArgumentException if hash length is wrong
+    * @since 0.1.1
+    */
+  def apply(spec: EdDSAParameterSpec, h: Array[Byte]): SHA3EdDSAPrivateKeySpec = {
+    if (h.length != b/4)
+      throw new IllegalArgumentException("hash length is wrong")
+
+    h(0) = (h(0) & 248.toByte).toByte
+    h((b/8)-1) = (h((b/8)-1) & 63.toByte).toByte
+    h((b/8)-1) = (h((b/8)-1) | 64.toByte).toByte
+
+    val a = util.Arrays.copyOfRange(h, 0, b/8)
+    val A = spec.getB.scalarMultiply(a)
+
+    new SHA3EdDSAPrivateKeySpec(null, h, a, A, spec)
+  }
+
+}
+
+object SHA3EdDSAParameterSpec {
+  private val spec = EdDSANamedCurveTable.getByName("Ed25519")
+  val curve: Curve = spec.getCurve
+  val hashAlgo: String = spec.getHashAlgorithm
+  val sc: ScalarOps = spec.getScalarOps
+  val B: GroupElement = spec.getB
+}
+
+class SHA3EdDSAParameterSpec extends
+  EdDSAParameterSpec(SHA3EdDSAParameterSpec.curve, SHA3EdDSAParameterSpec.hashAlgo,
+    SHA3EdDSAParameterSpec.sc, SHA3EdDSAParameterSpec.B) {
+
+  override def getHashAlgorithm: String = "SHA3-512"
+}
+


### PR DESCRIPTION
1. Changed ed25519 hash algorithm to SHA3-512.

SHA3EdDSAPrivateKeySpec is override class to use SHA3-512 as hash algorithm in Java8.

iroha v1 is change from SHA-512 to SHA3-512.

But it cannot get SHA3 instance by MessageDigest.getInstance in Java8.

And I didn't want to use Java9 because several dependencies.

So I created SHA3EdDSAPrivateKeySpec.

2. Updated proto files for iroha v1.

3. Updated validations for iroha v1.

Signed-off-by: SHIMADA, Daisuke <dice.k1984@gmail.com>