### PR TITLE
(+)Add a learning test for the behavior of tx_counter

### DIFF
--- a/src/main/scala/net/cimadai/iroha/Iroha.scala
+++ b/src/main/scala/net/cimadai/iroha/Iroha.scala
@@ -33,7 +33,7 @@ import org.bouncycastle.jcajce.provider.digest.SHA3
 case class ValidationError(reason: String)
 
 object Iroha {
-  private val txCounter = new AtomicLong(1)
+  val txCounter = new AtomicLong(1)
   private val queryCounter = new AtomicLong(1)
 
   implicit class EdDSAPublicKeyExt(pub: EdDSAPublicKey) {
@@ -120,7 +120,7 @@ object Iroha {
 
   // This emulates std::alnum.
   private def isAlphabetAndNumber(str: String): Boolean = {
-    str.matches("""^[a-z_0-9]+$""")
+    str.matches("""^[a-zA-Z_0-9]+$""")
   }
 
   private def isValidDomain(str: String): Boolean = {
@@ -172,11 +172,11 @@ object Iroha {
       new SHA3.Digest256().digest(transaction.payload.get.toByteArray)
     }
 
-    def createTransaction(creatorAccountId: IrohaAccountId, creatorKeyPair: Ed25519KeyPair, commands: Seq[Command]): Transaction = {
+    def createTransaction(creatorAccountId: IrohaAccountId, creatorKeyPair: Ed25519KeyPair, commands: Seq[Command], txCounter: Long = Iroha.txCounter.getAndIncrement()) = {
       val payload = Transaction.Payload(
         commands = commands,
         creatorAccountId = creatorAccountId.toString,
-        txCounter = txCounter.getAndIncrement(),
+        txCounter,
         createdTime = System.currentTimeMillis() - 2000000) // TODO: ugly hack. irohaノードより未来のタイムスタンプを渡すと失敗する。
 
       val sha3_256 = new SHA3.Digest256()
@@ -295,4 +295,3 @@ object Iroha {
   }
 
 }
-

--- a/src/test/scala/net/cimadai/iroha/IrohaSpec.scala
+++ b/src/test/scala/net/cimadai/iroha/IrohaSpec.scala
@@ -18,8 +18,8 @@ import scala.util.Random
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class IrohaSpec extends FunSpec {
-  private val grpcHost: String = sys.env.getOrElse("GRPC_HOST", "192.168.99.100")
-  private val grpcPort: Int = sys.env.getOrElse("GRPC_PORT", "31187").toInt
+  private val grpcHost: String = sys.env.getOrElse("GRPC_HOST", "127.0.0.1")
+  private val grpcPort: Int = sys.env.getOrElse("GRPC_PORT", "50051").toInt
   private val nodeNum: Int = sys.env.getOrElse("NODE_NUM", "4").toInt
   private val isSkipTxTest: Boolean = sys.env.getOrElse("SKIP_TX_TEST", "true").toBoolean
 

--- a/src/test/scala/net/cimadai/iroha/IrohaSpec.scala
+++ b/src/test/scala/net/cimadai/iroha/IrohaSpec.scala
@@ -89,7 +89,6 @@ class IrohaSpec extends FunSpec {
 
     def isCommitted(tx: Transaction): Boolean = {
       val response = askTransactionStatus(Iroha.CommandService.txStatusRequest(tx))
-      println(s"response = ${response}")
       response.txStatus == TxStatus.COMMITTED
     }
 
@@ -291,7 +290,6 @@ class IrohaSpec extends FunSpec {
 
         val user1keyPair = Iroha.createNewKeyPair()
         val user2keyPair = Iroha.createNewKeyPair()
-        println(user1keyPair.toHex.publicKey)
 
         val precision = IrohaAssetPrecision(3) // 小数点以下の桁数
 

--- a/src/test/scala/net/cimadai/iroha/IrohaSpec.scala
+++ b/src/test/scala/net/cimadai/iroha/IrohaSpec.scala
@@ -270,8 +270,6 @@ class IrohaSpec extends FunSpec {
     }
 
     it("tx_counter is to unique to each transaction creater.") {
-
-      val isSkipTxTest = false
       if (!isSkipTxTest) {
         val domain = IrohaDomainName("test.domain")
         val adminName = IrohaAccountName("admin")


### PR DESCRIPTION
# What is this pull request?

Add a test to learn the behavior of tx_counter. We wanted to make sure we can submit a transaction with the same tx_counter.

# Why do you implement it? Why do we need this pull request?

A test case for checking the behavior of  iroha node when it receives transactions with the same tx_counter.
