### PR TITLE
Feature/support SubtractAssetQuantity

### DIFF
--- a/src/main/scala/net/cimadai/iroha/Iroha.scala
+++ b/src/main/scala/net/cimadai/iroha/Iroha.scala
@@ -211,6 +211,9 @@ object Iroha {
     def setQuorum(accountId: IrohaAccountId, quorum: Int): Command =
       Command(SetQuorum(commands.SetAccountQuorum(accountId.toString, quorum)))
 
+    def subtractAssetQuantity(accountId: IrohaAccountId, assetId: IrohaAssetId, amount: IrohaAmount): Command =
+      Command(SubtractAssetQuantity(commands.SubtractAssetQuantity(accountId.toString, assetId.toString, Some(Amount(amount.value, amount.precision.value)))))
+
     def transferAsset(srcAccountId: IrohaAccountId, destAccountId: IrohaAccountId, assetId: IrohaAssetId, description: String, amount: IrohaAmount): Command =
       Command(TransferAsset(commands.TransferAsset(
         srcAccountId.toString,


### PR DESCRIPTION
# What is this pull request?

Support SubtractAssetQuantity of iroha's CommandService.

# Why do you implement it? Why do we need this pull request?

In order to invoke the iroha's SubtractAssetQuantity command.

# How to use the features provided in the pull request?

Create a command with `Iroha.CommandService.subtractAssetQuantity' method, and send the transaction containing the command.