### PR TITLE
(+): Support SubtractAssetQuantity

### DIFF
--- a/src/main/scala/net/cimadai/iroha/Iroha.scala
+++ b/src/main/scala/net/cimadai/iroha/Iroha.scala
@@ -211,6 +211,9 @@ object Iroha {
     def setQuorum(accountId: IrohaAccountId, quorum: Int): Command =
       Command(SetQuorum(commands.SetAccountQuorum(accountId.toString, quorum)))
 
+    def subtractAssetQuantity(accountId: IrohaAccountId, assetId: IrohaAssetId, amount: IrohaAmount): Command =
+      Command(SubtractAssetQuantity(commands.SubtractAssetQuantity(accountId.toString, assetId.toString, Some(Amount(amount.value, amount.precision.value)))))
+
     def transferAsset(srcAccountId: IrohaAccountId, destAccountId: IrohaAccountId, assetId: IrohaAssetId, description: String, amount: IrohaAmount): Command =
       Command(TransferAsset(commands.TransferAsset(
         srcAccountId.toString,

--- a/src/test/scala/net/cimadai/iroha/IrohaSpec.scala
+++ b/src/test/scala/net/cimadai/iroha/IrohaSpec.scala
@@ -336,7 +336,6 @@ class IrohaSpec extends FunSpec {
     }
 
     it("adding and subtracting the same amount result in the no change in balance.") {
-      val isSkipTxTest = false
       if (!isSkipTxTest) {
         val domain = IrohaDomainName("test.domain")
         val adminId = IrohaAccountId(IrohaAccountName("admin"), domain)


### PR DESCRIPTION
# What is this pull request?

Support SubtractAssetQuantity of iroha's CommandService.

# Why do you implement it? Why do we need this pull request?

In order to invoke the iroha's SubtractAssetQuantity command.

# How to use the features provided in the pull request?

Create a command with `Iroha.CommandService.subtractAssetQuantity' method, and send the transaction containing the command.